### PR TITLE
Add a fix for drop downs being white when hovered

### DIFF
--- a/jira-dark-gray.user.css
+++ b/jira-dark-gray.user.css
@@ -628,6 +628,12 @@ regexp(".*.atlassian.net/secure.*") {
     [data-role="droplistContent"] {
         background-color: #222;
     }
+    
+    /* Allows hover to be dark instead of white on all dropdowns */
+        [id^='react-select-']:hover {
+        background-color: #333 !important
+    }
+  
 
     /* pop up from dropdowns */
     .eJTYOk.eJTYOk {


### PR DESCRIPTION
This fix allows most of the dropdowns to be dark when hovered. 
(I specifically tested on the board - Epic, Label, Type, Group By, Three Dot Menu, Search bar dropdown, and a few others)

there is a random issue here where when you're in between hover and the next one it shows up white - unsure how to fix, will update later